### PR TITLE
Fix: this.advice is undefined

### DIFF
--- a/plugins/telegrambot.js
+++ b/plugins/telegrambot.js
@@ -20,6 +20,7 @@ var Actor = function () {
 util.makeEventEmitter(Actor);
 
 Actor.prototype.processAdvice = function (advice) {
+  this.advice = advice.recommendation;
   if (this.chatId) {
     var message;
     if (this.advice == 'long') {


### PR DESCRIPTION
In the original telegrambot plugin, this.advice is set to equal to advice.recommendation. I restored it in the processAdvice method as the else statement would run in the method, causing buy orders to be shown as sell orders (even though they are executed properly).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

/Buy shows a sell order message

* **What is the new behavior (if this is a feature change)?**

/Buy shows a buy order message

* **Other information**:
