### PR TITLE
Added flush() calls on the batchers

### DIFF
--- a/strategies/timeframes.js
+++ b/strategies/timeframes.js
@@ -78,6 +78,7 @@ strat.update = function(candle) {
 
   // write 1 minute candle to 15 minute batcher
   this.batcher15.write([candle]);
+  this.batcher15.flush();
 
 }
 
@@ -98,6 +99,7 @@ strat.update15 = function(candle) {
   
   // write 15 minute candle to 30 minute batcher
   this.batcher30.write([candle]);
+  this.batcher30.flush();
 }
 
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
The batcher doesn't emit the on.('candle') event due to the missing flush() call, hence the update15 and update30 handlers are never called.


* **What is the new behavior (if this is a feature change)?**
works as expected. The update 15 and update30 handlers are called on every 15 and 30 minute candles.


* **Other information**:
